### PR TITLE
fix: use different origins patterns for Debian

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,13 @@
 ---
 - name: add distribution-specific variables
-  ansible.builtin.include_vars:
-    file: "{{ ansible_distribution }}.yml"
+  ansible.builtin.include_vars: "{{ lookup('first_found', params) }}"
+  vars:
+    params:
+      files:
+        - '{{ ansible_distribution }}-{{ ansible_distribution_major_version }}.yml'
+        - '{{ ansible_distribution }}.yml'
+      paths:
+        - 'vars'
   tags:
     - unattended_upgrades
     - unattended_upgrades.include_dist_vars

--- a/vars/Debian-11.yml
+++ b/vars/Debian-11.yml
@@ -1,0 +1,4 @@
+---
+__unattended_upgrades_origins_patterns:
+  - 'origin=Debian,codename=${distro_codename}-security,label=Debian-Security'
+...

--- a/vars/Debian-7.yml
+++ b/vars/Debian-7.yml
@@ -1,0 +1,11 @@
+---
+# This workaround for Debian Wheezy which doesn't support ${distro_codename} macro
+# See
+#   https://github.com/jnv/ansible-role-unattended-upgrades/issues/19
+#   https://github.com/jnv/ansible-role-unattended-upgrades/pull/20
+# for details
+
+__unattended_origins_patterns:
+  - 'origin=Debian,archive=stable,label=Debian-Security'
+  - 'origin=Debian,archive=oldstable,label=Debian-Security'
+...


### PR DESCRIPTION
Use new codename for Debian Bullseye and a workaround for Debian Wheezy.